### PR TITLE
feat:nodejs support and send transaction call

### DIFF
--- a/lib/api.d.ts
+++ b/lib/api.d.ts
@@ -1,7 +1,8 @@
 export declare type RocksideNetwork = [3, 'ropsten'] | [1, 'mainnet'];
 export declare type RocksideApiOpts = {
     baseUrl: string;
-    token: string;
+    token?: string;
+    apikey?: string;
     network: RocksideNetwork;
 };
 export declare type ExecuteTransaction = {
@@ -29,13 +30,29 @@ export declare type IdentityResponse = {
     address: string;
     transactionHash: string;
 };
+export declare type TransactionOpts = {
+    from: string;
+    to: string;
+    value?: string | number | BigInt;
+    gas?: string | number | BigInt;
+    gasPrice?: string | number | BigInt;
+    data?: string;
+    nonce?: number;
+};
 export declare class RocksideApi {
     private readonly opts;
+    private readonly headers;
+    private generateHeaders;
+    private authenticationChecks;
     constructor(opts: RocksideApiOpts);
     private extractError;
     private send;
     getIdentities(): Promise<string[]>;
     createIdentity(): Promise<IdentityResponse>;
+    sendTransaction(tx: TransactionOpts): Promise<{
+        transaction_hash: string;
+        tracking_id: string;
+    }>;
     createEncryptedAccount(account: EncryptedAccount): Promise<void>;
     connectEncryptedAccount(username: string, passwordHash: ArrayBuffer): Promise<{
         data: ArrayBuffer;

--- a/lib/api.js
+++ b/lib/api.js
@@ -36,10 +36,33 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+var cross_fetch_1 = require("cross-fetch");
 var RocksideApi = /** @class */ (function () {
     function RocksideApi(opts) {
+        this.authenticationChecks(opts);
+        this.headers = this.generateHeaders(opts);
         this.opts = opts;
     }
+    RocksideApi.prototype.generateHeaders = function (opts) {
+        if (opts.apikey) {
+            return {
+                'apikey': opts.apikey
+            };
+        }
+        else {
+            return {
+                'Authorization': 'Bearer ' + opts.token,
+            };
+        }
+    };
+    RocksideApi.prototype.authenticationChecks = function (opts) {
+        if (opts.apikey && opts.token) {
+            throw new Error("Both access token and api key provided. Only one needed.");
+        }
+        if (!opts.apikey && !opts.token) {
+            throw new Error("No authentication method provided: define apikey or token.");
+        }
+    };
     RocksideApi.prototype.extractError = function (resp) {
         return __awaiter(this, void 0, void 0, function () {
             var json;
@@ -48,7 +71,7 @@ var RocksideApi = /** @class */ (function () {
                     case 0: return [4 /*yield*/, resp.json()];
                     case 1:
                         json = _a.sent();
-                        throw new Error(json["error"]);
+                        throw new Error(json['error']);
                 }
             });
         });
@@ -60,12 +83,10 @@ var RocksideApi = /** @class */ (function () {
                 switch (_a.label) {
                     case 0:
                         url = "" + this.opts.baseUrl + route;
-                        return [4 /*yield*/, fetch(url, {
+                        return [4 /*yield*/, cross_fetch_1.default(url, {
                                 method: method,
                                 body: !!body ? JSON.stringify(body) : null,
-                                headers: {
-                                    "Authorization": "Bearer " + this.opts.token,
-                                },
+                                headers: this.headers,
                             })];
                     case 1: return [2 /*return*/, _a.sent()];
                 }
@@ -108,6 +129,28 @@ var RocksideApi = /** @class */ (function () {
                         return [2 /*return*/, {
                                 address: json.address,
                                 transactionHash: json.transaction_hash,
+                            }];
+                }
+            });
+        });
+    };
+    RocksideApi.prototype.sendTransaction = function (tx) {
+        return __awaiter(this, void 0, void 0, function () {
+            var resp, json;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.send("/ethereum/" + this.opts.network[1] + "/transaction", 'POST', tx)];
+                    case 1:
+                        resp = _a.sent();
+                        if (!(resp.status !== 200)) return [3 /*break*/, 3];
+                        return [4 /*yield*/, this.extractError(resp)];
+                    case 2: throw _a.sent();
+                    case 3: return [4 /*yield*/, resp.json()];
+                    case 4:
+                        json = _a.sent();
+                        return [2 /*return*/, {
+                                transaction_hash: json['transaction_hash'],
+                                tracking_id: json['tracking_id']
                             }];
                 }
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "rockside-sdk-wallet",
+  "name": "@rocksideio/rockside-wallet-sdk",
   "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
@@ -1168,6 +1168,11 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
+    "browser-or-node": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-1.2.1.tgz",
+      "integrity": "sha512-sVIA0cysIED0nbmNOm7sZzKfgN1rpFmrqvLZaFWspaBAftfQcezlC81G6j6U2RJf4Lh66zFxrCeOsvkUXIcPWg=="
+    },
     "browser-process-hrtime": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
@@ -1490,6 +1495,22 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
+      "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
+      "requires": {
+        "node-fetch": "2.6.0",
+        "whatwg-fetch": "3.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        }
       }
     },
     "cross-spawn": {
@@ -6163,6 +6184,11 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "bip39": "^3.0.2",
+    "cross-fetch": "^3.0.4",
     "eth-json-rpc-middleware": "^4.4.1",
     "eth-sig-util": "^2.5.2",
     "ethereumjs-util": "^6.2.0",


### PR DESCRIPTION
- Add the `cross-fetch` module to make the `RocksideApi` work both in browser and nodejs
- Add the `sendTransaction` method to the `RocksideApi` class, taking the same arguments as the `web3` method